### PR TITLE
feat(ApiTokenAuth): Add support for using PiHole's api token

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ $ docker run \
   ekofr/pihole-exporter:latest
 ```
 
+Or use PiHole's `WEBPASSWORD` as an API token instead of the password
+
+```bash
+$ API_TOKEN=$(awk -F= -v key="WEBPASSWORD" '$1==key {print $2}' /etc/pihole/setupVars.conf)
+$ docker run \
+  -e 'PIHOLE_HOSTNAME=192.168.1.2' \
+  -e "PIHOLE_APITOKEN=$API_TOKEN" \
+  -e 'INTERVAL=30s' \
+  -e 'PORT=9617' \
+  ekofr/pihole-exporter:latest
+```
+
 ### From sources
 
 Optionally, you can download and build it from the sources. You have to retrieve the project sources by using one of the following way:
@@ -72,9 +84,20 @@ $ GOOS=linux GOARCH=arm GOARM=7 go build -o pihole_exporter .
 
 In order to run the exporter, type the following command (arguments are optional):
 
+Using a password
+
 ```bash
 $ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_password azerty
+```
 
+Or use PiHole's `WEBPASSWORD` as an API token instead of the password
+
+```bash
+$ API_TOKEN=$(awk -F= -v key="WEBPASSWORD" '$1==key {print $2}' /etc/pihole/setupVars.conf)
+$ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_apitoken $API_TOKEN
+```
+
+```bash
 2019/05/09 20:19:52 ------------------------------------
 2019/05/09 20:19:52 -  PI-Hole exporter configuration  -
 2019/05/09 20:19:52 ------------------------------------
@@ -124,6 +147,10 @@ scrape_configs:
 
 # Password defined on the PI-Hole interface
   -pihole_password string (optional)
+
+
+# WEBPASSWORD / api token defined on the PI-Hole interface at `/etc/pihole/setupVars.conf`
+  -pihole_apitoken string (optional)
 
 # Port to be used for the exporter
   -port string (optional) (default "9617")

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Or use PiHole's `WEBPASSWORD` as an API token instead of the password
 $ API_TOKEN=$(awk -F= -v key="WEBPASSWORD" '$1==key {print $2}' /etc/pihole/setupVars.conf)
 $ docker run \
   -e 'PIHOLE_HOSTNAME=192.168.1.2' \
-  -e "PIHOLE_APITOKEN=$API_TOKEN" \
+  -e "PIHOLE_API_TOKEN=$API_TOKEN" \
   -e 'INTERVAL=30s' \
   -e 'PORT=9617' \
   ekofr/pihole-exporter:latest
@@ -94,7 +94,7 @@ Or use PiHole's `WEBPASSWORD` as an API token instead of the password
 
 ```bash
 $ API_TOKEN=$(awk -F= -v key="WEBPASSWORD" '$1==key {print $2}' /etc/pihole/setupVars.conf)
-$ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_apitoken $API_TOKEN
+$ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_api_token $API_TOKEN
 ```
 
 ```bash
@@ -150,7 +150,7 @@ scrape_configs:
 
 
 # WEBPASSWORD / api token defined on the PI-Hole interface at `/etc/pihole/setupVars.conf`
-  -pihole_apitoken string (optional)
+  -pihole_api_token string (optional)
 
 # Port to be used for the exporter
   -port string (optional) (default "9617")

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,20 +15,20 @@ import (
 
 // Config is the exporter CLI configuration.
 type Config struct {
-	PIHoleHostname string `config:"pihole_hostname"`
-	PIHolePassword string `config:"pihole_password"`
-
-	Port     string        `config:"port"`
-	Interval time.Duration `config:"interval"`
+	PIHoleHostname string        `config:"pihole_hostname"`
+	PIHolePassword string        `config:"pihole_password"`
+	PIHoleApiToken string        `config:"pihole_apitoken"`
+	Port           string        `config:"port"`
+	Interval       time.Duration `config:"interval"`
 }
 
 func getDefaultConfig() *Config {
 	return &Config{
 		PIHoleHostname: "127.0.0.1",
 		PIHolePassword: "",
-
-		Port:     "9617",
-		Interval: 10 * time.Second,
+		PIHoleApiToken: "",
+		Port:           "9617",
+		Interval:       10 * time.Second,
 	}
 }
 
@@ -61,10 +61,18 @@ func (c Config) show() {
 		valueField := val.Field(i)
 		typeField := val.Type().Field(i)
 
-		// Do not print password
-		if typeField.Name != "PIHolePassword" {
+		// Do not print password or api token but do print the authentication method
+		if typeField.Name != "PIHolePassword" && typeField.Name != "PIHoleApiToken" {
 			log.Println(fmt.Sprintf("%s : %v", typeField.Name, valueField.Interface()))
+		} else {
+			showAuthenticationMethod(typeField.Name, valueField.String())
 		}
 	}
 	log.Println("------------------------------------")
+}
+
+func showAuthenticationMethod(name, value string) {
+	if len(value) > 0 {
+		log.Println(fmt.Sprintf("PiHole Authentication Method : %s", name))
+	}
 }

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -17,7 +17,7 @@ import (
 type Config struct {
 	PIHoleHostname string        `config:"pihole_hostname"`
 	PIHolePassword string        `config:"pihole_password"`
-	PIHoleApiToken string        `config:"pihole_apitoken"`
+	PIHoleApiToken string        `config:"pihole_api_token"`
 	Port           string        `config:"port"`
 	Interval       time.Duration `config:"interval"`
 }
@@ -73,6 +73,6 @@ func (c Config) show() {
 
 func showAuthenticationMethod(name, value string) {
 	if len(value) > 0 {
-		log.Println(fmt.Sprintf("PiHole Authentication Method : %s", name))
+		log.Println(fmt.Sprintf("Pi-Hole Authentication Method : %s", name))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ func main() {
 
 	metrics.Init()
 
-	initPiholeClient(conf.PIHoleHostname, conf.PIHolePassword, conf.Interval)
+	initPiHoleClient(conf.PIHoleHostname, conf.PIHolePassword, conf.PIHoleApiToken, conf.Interval)
 	initHttpServer(conf.Port)
 
 	handleExitSignal()
 }
 
-func initPiholeClient(hostname, password string, interval time.Duration) {
-	client := pihole.NewClient(hostname, password, interval)
+func initPiHoleClient(hostname, password, apiToken string, interval time.Duration) {
+	client := pihole.NewClient(hostname, password, apiToken, interval)
 	go client.Scrape()
 }
 


### PR DESCRIPTION
This PR adds support for using PiHole's api token also known as `WEBPASSWORD` found at `/etc/pihole/setupVars.conf` when running `pihole-exporter`

Helm chart PR: https://github.com/SiM22/pihole-exporter-helm-chart/pull/5