### PR TITLE
add support for pi-hole running behind https

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ $ docker run \
   ekofr/pihole-exporter:latest
 ```
 
+If you are running pi-hole behind https, you must both set the `PIHOLE_PROTOCOL` environment variable
+as well as include your ssl certificates to the docker image as it does not have any baked in:
+
+```
+$ docker run \
+  -e 'PIHOLE_PROTOCOL=https' \
+  -e 'PIHOLE_HOSTNAME=192.168.1.2' \
+  -e 'PIHOLE_PASSWORD=mypassword' \
+  -e 'INTERVAL=30s' \
+  -e 'PORT=9617' \
+  -v '/etc/ssl/certs:/etc/ssl/certs:ro' \
+  -p 9617:9617 \
+  ekofr/pihole-exporter:latest
+```
+
 ### From sources
 
 Optionally, you can download and build it from the sources. You have to retrieve the project sources by using one of the following way:

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,6 +15,7 @@ import (
 
 // Config is the exporter CLI configuration.
 type Config struct {
+	PIHoleProtocol string        `config:"pihole_protocol"`
 	PIHoleHostname string        `config:"pihole_hostname"`
 	PIHolePassword string        `config:"pihole_password"`
 	PIHoleApiToken string        `config:"pihole_api_token"`
@@ -24,6 +25,7 @@ type Config struct {
 
 func getDefaultConfig() *Config {
 	return &Config{
+		PIHoleProtocol: "http",
 		PIHoleHostname: "127.0.0.1",
 		PIHolePassword: "",
 		PIHoleApiToken: "",

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ func main() {
 
 	metrics.Init()
 
-	initPiHoleClient(conf.PIHoleHostname, conf.PIHolePassword, conf.PIHoleApiToken, conf.Interval)
+	initPiHoleClient(conf.PIHoleProtocol, conf.PIHoleHostname, conf.PIHolePassword, conf.PIHoleApiToken, conf.Interval)
 	initHttpServer(conf.Port)
 
 	handleExitSignal()
 }
 
-func initPiHoleClient(hostname, password, apiToken string, interval time.Duration) {
-	client := pihole.NewClient(hostname, password, apiToken, interval)
+func initPiHoleClient(protocol, hostname, password, apiToken string, interval time.Duration) {
+	client := pihole.NewClient(protocol, hostname, password, apiToken, interval)
 	go client.Scrape()
 }
 


### PR DESCRIPTION
This adds support for a new environment variable `PIHOLE_PROTOCOL`,
which defaults to `http`.

I run my pi-hole behind https and was unable to collect metrics until I made this change.

This should have no impact to existing users as those who don't set this variable will get the old value `http`. The value is validated to be either `http` or `https` and the application will exit non-zero and output an error message if the value is not one of those.

commit contains documentation update.

This is the very first golang code I've ever written. I hope it's idiomatic and I tried to match your style. Let me know if you'd like me to make any changes.