### PR TITLE
Fix json format of dashboard.json

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1,5 +1,4 @@
 {
-{
   "__inputs": [
     {
       "name": "DS_PROMETHEUS",


### PR DESCRIPTION
There was a "{" at the first line that isnt needed and coused an error when importing the raw json in grafana