### PR TITLE
Update test matrix for supported go versions and add example docker-compose.yml

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: [ '1.12', '1.13', '1.14' ]
+        go_version: [ '1.13', '1.14', '1.15', '1.16', '1.17' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.6"
+services:
+  pihole_exporter:
+    build:
+      context: ./
+      args:
+        ARCH: CHANGE_ME
+      dockerfile: Dockerfile
+    image: ekofr/pihole-exporter:arm64
+    container_name: pihole_exporter
+    expose:
+      - 9617
+    environment:
+      PIHOLE_HOSTNAME: CHANG_EME 
+      PIHOLE_PORT: CHANGE_ME
+      PIHOLE_PASSWORD: CHANGE_ME
+      INTERVAL: 30s
+      PORT: 9617
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     expose:
       - 9617
     environment:
-      PIHOLE_HOSTNAME: CHANG_EME 
+      PIHOLE_HOSTNAME: CHANGE_ME 
       PIHOLE_PORT: CHANGE_ME
       PIHOLE_PASSWORD: CHANGE_ME
       INTERVAL: 30s


### PR DESCRIPTION
    Go version 1.12 does not support the %w case which requires go >= 1.13.
    This resolves the build tests partially failing since 26ddc36a4efbec8c64666c6ce95bd959d9d91bbd
    Additionally as we are upgrading to 1.17 for various things ensure that
    we test up to those latest version we support

    Give a practical docker-compose.yml example to make it easier for people
    to build and or run within their own compose setups. This should help users who are building via issue in #73 