### PR TITLE
Support multiple pihole instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,33 @@ $ docker run \
   ekofr/pihole-exporter:latest
 ```
 
+A single instance of pihole-exporter can monitor multiple pi-holes instances.
+To do so, you can specify a list of hostnames, protocols, passwords/API tokens and ports by separating them with commas in their respective environment variable:
+
+```
+$ docker run \
+  -e 'PIHOLE_PROTOCOL="http,http,http" \
+  -e 'PIHOLE_HOSTNAME="192.168.1.2,192.168.1.3,192.168.1.4"' \
+  -e "PIHOLE_API_TOKEN="$API_TOKEN1,$API_TOKEN2,$API_TOKEN3" \
+  -e "PIHOLE_PORT="8080,8081,8080" \
+  -e 'INTERVAL=30s' \
+  -e 'PORT=9617' \
+  ekofr/pihole-exporter:latest
+```
+
+If port, protocol and API token/password is the same for all instances, you can specify them only once:
+
+```
+$ docker run \
+  -e 'PIHOLE_PROTOCOL=",http" \
+  -e 'PIHOLE_HOSTNAME="192.168.1.2,192.168.1.3,192.168.1.4"' \
+  -e "PIHOLE_API_TOKEN="$API_TOKEN" \
+  -e "PIHOLE_PORT="8080" \
+  -e 'INTERVAL=30s' \
+  -e 'PORT=9617' \
+  ekofr/pihole-exporter:latest
+```
+
 ### From sources
 
 Optionally, you can download and build it from the sources. You have to retrieve the project sources by using one of the following way:

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/heetch/confita"
@@ -62,6 +63,20 @@ func Load() (*EnvConfig, []Config) {
 	cfg.show()
 
 	return cfg, cfg.Split()
+}
+
+func (c *Config) String() string {
+	ref := reflect.ValueOf(c)
+	fields := ref.Elem()
+
+	buffer := make([]string, fields.NumField(), fields.NumField())
+	for i := 0; i < fields.NumField(); i++ {
+		valueField := fields.Field(i)
+		typeField := fields.Type().Field(i)
+		buffer[i] = fmt.Sprintf("%s=%v", typeField.Name, valueField.Interface())
+	}
+
+	return fmt.Sprintf("<Config@%X %s>", &c, strings.Join(buffer, ", "))
 }
 
 //Validate check if the config is valid

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,29 +15,37 @@ import (
 
 // Config is the exporter CLI configuration.
 type Config struct {
-	PIHoleProtocol string        `config:"pihole_protocol"`
-	PIHoleHostname string        `config:"pihole_hostname"`
-	PIHolePort     uint16        `config:"pihole_port"`
-	PIHolePassword string        `config:"pihole_password"`
-	PIHoleApiToken string        `config:"pihole_api_token"`
-	Port           string        `config:"port"`
+	PIHoleProtocol string `config:"pihole_protocol"`
+	PIHoleHostname string `config:"pihole_hostname"`
+	PIHolePort     uint16 `config:"pihole_port"`
+	PIHolePassword string `config:"pihole_password"`
+	PIHoleApiToken string `config:"pihole_api_token"`
+}
+
+type EnvConfig struct {
+	PIHoleProtocol []string      `config:"pihole_protocol"`
+	PIHoleHostname []string      `config:"pihole_hostname"`
+	PIHolePort     []uint16      `config:"pihole_port"`
+	PIHolePassword []string      `config:"pihole_password"`
+	PIHoleApiToken []string      `config:"pihole_api_token"`
+	Port           uint16        `config:"port"`
 	Interval       time.Duration `config:"interval"`
 }
 
-func getDefaultConfig() *Config {
-	return &Config{
-		PIHoleProtocol: "http",
-		PIHoleHostname: "127.0.0.1",
-		PIHolePort:     80,
-		PIHolePassword: "",
-		PIHoleApiToken: "",
-		Port:           "9617",
+func getDefaultEnvConfig() *EnvConfig {
+	return &EnvConfig{
+		PIHoleProtocol: []string{"http"},
+		PIHoleHostname: []string{"127.0.0.1"},
+		PIHolePort:     []uint16{80},
+		PIHolePassword: []string{},
+		PIHoleApiToken: []string{},
+		Port:           9617,
 		Interval:       10 * time.Second,
 	}
 }
 
 // Load method loads the configuration by using both flag or environment variables.
-func Load() *Config {
+func Load() (*EnvConfig, []Config) {
 	loaders := []backend.Backend{
 		env.NewBackend(),
 		flags.NewBackend(),
@@ -45,7 +53,7 @@ func Load() *Config {
 
 	loader := confita.NewLoader(loaders...)
 
-	cfg := getDefaultConfig()
+	cfg := getDefaultEnvConfig()
 	err := loader.Load(context.Background(), cfg)
 	if err != nil {
 		panic(err)
@@ -53,7 +61,7 @@ func Load() *Config {
 
 	cfg.show()
 
-	return cfg
+	return cfg, cfg.Split()
 }
 
 //Validate check if the config is valid
@@ -62,6 +70,33 @@ func (c Config) Validate() error {
 		return fmt.Errorf("protocol %s is invalid. Must be http or https", c.PIHoleProtocol)
 	}
 	return nil
+}
+
+func (c EnvConfig) Split() []Config {
+	result := make([]Config, 0, len(c.PIHoleHostname))
+
+	for i, hostname := range c.PIHoleHostname {
+		config := Config{
+			PIHoleHostname: hostname,
+			PIHoleProtocol: c.PIHoleProtocol[i],
+			PIHolePort:     c.PIHolePort[i],
+		}
+
+		if c.PIHoleApiToken != nil && len(c.PIHoleApiToken) > 0 {
+			if c.PIHoleApiToken[i] != "" {
+				config.PIHoleApiToken = c.PIHoleApiToken[i]
+			}
+		}
+
+		if c.PIHolePassword != nil && len(c.PIHolePassword) > 0 {
+			if c.PIHolePassword[i] != "" {
+				config.PIHolePassword = c.PIHolePassword[i]
+			}
+		}
+
+		result = append(result, config)
+	}
+	return result
 }
 
 func (c Config) hostnameURL() string {
@@ -82,7 +117,7 @@ func (c Config) PIHoleLoginURL() string {
 	return c.hostnameURL() + "/admin/index.php?login"
 }
 
-func (c Config) show() {
+func (c EnvConfig) show() {
 	val := reflect.ValueOf(&c).Elem()
 	log.Println("------------------------------------")
 	log.Println("-  PI-Hole exporter configuration  -")
@@ -95,14 +130,14 @@ func (c Config) show() {
 		if typeField.Name != "PIHolePassword" && typeField.Name != "PIHoleApiToken" {
 			log.Println(fmt.Sprintf("%s : %v", typeField.Name, valueField.Interface()))
 		} else {
-			showAuthenticationMethod(typeField.Name, valueField.String())
+			showAuthenticationMethod(typeField.Name, valueField.Len())
 		}
 	}
 	log.Println("------------------------------------")
 }
 
-func showAuthenticationMethod(name, value string) {
-	if len(value) > 0 {
+func showAuthenticationMethod(name string, length int) {
+	if length > 0 {
 		log.Println(fmt.Sprintf("Pi-Hole Authentication Method : %s", name))
 	}
 }

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -97,15 +97,27 @@ func (c EnvConfig) Split() []Config {
 			PIHolePort:     c.PIHolePort[i],
 		}
 
-		if c.PIHoleApiToken != nil && len(c.PIHoleApiToken) > 0 {
-			if c.PIHoleApiToken[i] != "" {
-				config.PIHoleApiToken = c.PIHoleApiToken[i]
+		if c.PIHoleApiToken != nil {
+			if len(c.PIHoleApiToken) == 1 {
+				if c.PIHoleApiToken[0] != "" {
+					config.PIHoleApiToken = c.PIHoleApiToken[0]
+				}
+			} else if len(c.PIHoleApiToken) > 1 {
+				if c.PIHoleApiToken[i] != "" {
+					config.PIHoleApiToken = c.PIHoleApiToken[i]
+				}
 			}
 		}
 
-		if c.PIHolePassword != nil && len(c.PIHolePassword) > 0 {
-			if c.PIHolePassword[i] != "" {
-				config.PIHolePassword = c.PIHolePassword[i]
+		if c.PIHolePassword != nil {
+			if len(c.PIHolePassword) == 1 {
+				if c.PIHolePassword[0] != "" {
+					config.PIHolePassword = c.PIHolePassword[0]
+				}
+			} else if len(c.PIHolePassword) > 1 {
+				if c.PIHolePassword[i] != "" {
+					config.PIHolePassword = c.PIHolePassword[i]
+				}
 			}
 		}
 

--- a/internal/pihole/model.go
+++ b/internal/pihole/model.go
@@ -31,6 +31,6 @@ type Stats struct {
 }
 
 // ToString method returns a string of the current statistics struct.
-func (s *Stats) ToString() string {
+func (s *Stats) String() string {
 	return fmt.Sprintf("%d ads blocked / %d total DNS queries", s.AdsBlockedToday, s.DNSQueriesAllTypes)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,11 +28,6 @@ func NewServer(port uint16, clients []*pihole.Client) *Server {
 		httpServer: httpServer,
 	}
 
-	/*fmt.Printf("Server received clients -> %s\n", clients)
-	for i, client := range clients {
-		fmt.Printf("Server received clients -> idx: %d, Hostname: %s\n", i, &client)
-	}*/
-
 	mux.HandleFunc("/metrics",
 		func(writer http.ResponseWriter, request *http.Request) {
 			errors := make([]string, 0)
@@ -54,7 +49,6 @@ func NewServer(port uint16, clients []*pihole.Client) *Server {
 		},
 	)
 
-	//mux.Handle("/metrics", client.Metrics())
 	mux.Handle("/readiness", s.readinessHandler())
 	mux.Handle("/liveness", s.livenessHandler())
 

--- a/main.go
+++ b/main.go
@@ -11,12 +11,19 @@ import (
 )
 
 func main() {
-	conf := config.Load()
+	envConf, clientConfigs := config.Load()
 
 	metrics.Init()
 
 	serverDead := make(chan struct{})
-	s := server.NewServer(conf.Port, pihole.NewClient(conf))
+	clients := make([]*pihole.Client, 0, len(clientConfigs))
+	for i, _ := range clientConfigs {
+		client := pihole.NewClient(&clientConfigs[i])
+		clients = append(clients, client)
+		fmt.Printf("Append client %s\n", clients)
+	}
+
+	s := server.NewServer(envConf.Port, clients)
 	go func() {
 		s.ListenAndServe()
 		close(serverDead)

--- a/main.go
+++ b/main.go
@@ -16,12 +16,8 @@ func main() {
 	metrics.Init()
 
 	serverDead := make(chan struct{})
-	clients := make([]*pihole.Client, 0, len(clientConfigs))
-	for i, _ := range clientConfigs {
-		client := pihole.NewClient(&clientConfigs[i])
-		clients = append(clients, client)
-		fmt.Printf("Append client %s\n", clients)
-	}
+
+	clients := buildClients(clientConfigs)
 
 	s := server.NewServer(envConf.Port, clients)
 	go func() {
@@ -42,4 +38,15 @@ func main() {
 	}
 
 	fmt.Println("pihole-exporter HTTP server stopped")
+}
+
+func buildClients(clientConfigs []config.Config) []*pihole.Client {
+	clients := make([]*pihole.Client, 0, len(clientConfigs))
+	for i := range clientConfigs {
+		clientConfig := &clientConfigs[i]
+
+		client := pihole.NewClient(clientConfig)
+		clients = append(clients, client)
+	}
+	return clients
 }


### PR DESCRIPTION
Multiple PiHole instances can be monitored by specifying multiple addresses separated by commas in the `PIHOLE_HOSTNAME` variable.

If the instances use the same protocol, port and API token/password, they can be specified only once the respective environment variables.

If the instances use different protocols, ports and API token/password, they can be specified the respective environment variables, separated by commas.