### PR TITLE
Removed print of token/password in logs

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -78,7 +78,13 @@ func (c *Config) String() string {
 	for i := 0; i < fields.NumField(); i++ {
 		valueField := fields.Field(i)
 		typeField := fields.Type().Field(i)
-		buffer[i] = fmt.Sprintf("%s=%v", typeField.Name, valueField.Interface())
+		if typeField.Name != "PIHolePassword" && typeField.Name != "PIHoleApiToken" {
+			buffer[i] = fmt.Sprintf("%s=%v", typeField.Name, valueField.Interface())
+		} else {
+			if valueField.Len() > 0 {
+				buffer[i] = fmt.Sprintf("%s=%s", typeField.Name, "*****")
+			}
+		}
 	}
 
 	return fmt.Sprintf("<Config@%X %s>", &c, strings.Join(buffer, ", "))

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -81,8 +81,7 @@ func (c *Config) String() string {
 		if typeField.Name != "PIHolePassword" && typeField.Name != "PIHoleApiToken" {
 			buffer[i] = fmt.Sprintf("%s=%v", typeField.Name, valueField.Interface())
 		} else if valueField.Len() > 0 {
-				buffer[i] = fmt.Sprintf("%s=%s", typeField.Name, "*****")
-			}
+			buffer[i] = fmt.Sprintf("%s=%s", typeField.Name, "*****")
 		}
 	}
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -80,8 +80,7 @@ func (c *Config) String() string {
 		typeField := fields.Type().Field(i)
 		if typeField.Name != "PIHolePassword" && typeField.Name != "PIHoleApiToken" {
 			buffer[i] = fmt.Sprintf("%s=%v", typeField.Name, valueField.Interface())
-		} else {
-			if valueField.Len() > 0 {
+		} else if valueField.Len() > 0 {
 				buffer[i] = fmt.Sprintf("%s=%s", typeField.Name, "*****")
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,19 @@ require (
 	github.com/xonvanetta/shutdown v0.0.3
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 )
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -9,19 +9,3 @@ require (
 	github.com/xonvanetta/shutdown v0.0.3
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 )
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.26.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
-	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
-	google.golang.org/protobuf v1.26.0-rc.1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -31,7 +31,7 @@ func NewClient(config *config.Config) *Client {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Creating client with config %s\n", config)
+	log.Printf("Creating client with config %s\n", config)
 
 	return &Client{
 		config: config,

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/eko/pihole-exporter/config"
@@ -41,7 +40,7 @@ func main() {
 	case <-serverDead:
 	}
 
-	fmt.Println("pihole-exporter HTTP server stopped")
+	log.Println("pihole-exporter HTTP server stopped")
 }
 
 func buildClients(clientConfigs []config.Config) []*pihole.Client {


### PR DESCRIPTION
As per title.
Removed a log line that was printing the api token or password.
The same log now just print the field name (if value is not empty) and the value is redacted.