### PR TITLE
Added `push=true` to docker build output

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         docker buildx build \
           --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
-          --output=type=registry \
+          --output=type=registry,push=true \
           --tag ekofr/pihole-exporter:${{ steps.get_version.outputs.TAG_NAME }} \
           .
 


### PR DESCRIPTION
As mentioned in Issue #130 (and as seen in the [lack of architecture tags in the Dockerhub listing for this image](https://hub.docker.com/r/ekofr/pihole-exporter), it currently does not seem that every platform's docker builds are being uploaded to Dockerhub.  Based on [this comment in the buildx repo](https://github.com/docker/buildx/issues/166#issuecomment-544617936), it seems that `push=true` needs to be added to force docker to push all the platforms to the registry, so have opened this PR to add it.

If I am super wrong / have missed something obvious, feel free to eviscerate this PR as you see fit, you will not offend me :)