### PR TITLE
Added workflow step to tag and push the docker image with `latest` tag on push to `master`

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -52,6 +52,12 @@ jobs:
           --tag ekofr/pihole-exporter:${{ steps.get_version.outputs.TAG_NAME }} \
           .
 
+    - name: Tag and push latest tag on master push
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      run: |
+        docker image tag ekofr/pihole-exporter:${{ steps.get_version.outputs.TAG_NAME }} ekofr/pihole-exporter:latest
+        docker image push ekofr/pihole-exporter:latest
+
   release:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
As described in issue #119, currently the `latest` tag is not being updated when new builds are being published to Dockerhub.  This PR therefore adds an extra conditional step on pushes to the `master` branch to tag the image with the `latest` tag and push it as well.

Not sure if this is the most efficient way to do this so feel free to recommend better ways to do it / trash the PR.