### PR TITLE
docs: Updating docker run commands with missing port mapping for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ docker run \
   -e 'PIHOLE_HOSTNAME=192.168.1.2' \
   -e "PIHOLE_API_TOKEN=$API_TOKEN" \
   -e 'PORT=9617' \
+  -p 9617:9617 \
   ekofr/pihole-exporter:latest
 ```
 
@@ -86,6 +87,7 @@ $ docker run \
   -e "PIHOLE_API_TOKEN="$API_TOKEN1,$API_TOKEN2,$API_TOKEN3" \
   -e "PIHOLE_PORT="8080,8081,8080" \
   -e 'PORT=9617' \
+  -p 9617:9617 \
   ekofr/pihole-exporter:latest
 ```
 
@@ -98,6 +100,7 @@ $ docker run \
   -e "PIHOLE_API_TOKEN="$API_TOKEN" \
   -e "PIHOLE_PORT="8080" \
   -e 'PORT=9617' \
+  -p 9617:9617 \
   ekofr/pihole-exporter:latest
 ```
 


### PR DESCRIPTION
👋 I was trying out the different docker run usage options and realized a few examples in the README.md were missing port mappings.  This corrects that

