### PR TITLE
Adding warning logging if full metrics set is not available.

### DIFF
--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -125,6 +125,12 @@ func (c *Client) setMetrics(stats *Stats) {
 	}
 	metrics.Status.WithLabelValues(c.config.PIHoleHostname).Set(float64(isEnabled))
 
+	// Pi-Hole returns a subset of stats when Auth is missing or incorrect.
+	// This provides a warning to users that metrics are not complete.
+	if len(stats.TopQueries) == 0 {
+		log.Warnf("Invalid Authentication - Some metrics may be missing. Please confirm your PI-Hole API token / Password for %s", c.config.PIHoleHostname)
+	}
+
 	for domain, value := range stats.TopQueries {
 		metrics.TopQueries.WithLabelValues(c.config.PIHoleHostname, domain).Set(float64(value))
 	}


### PR DESCRIPTION
This will inform the user that pi-hole auth is missing or incorrect and some metrics will be missing from the exporter

related: https://github.com/eko/pihole-exporter/issues/111