### PR TITLE
Update README.md 'From Source' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ docker run \
 
 Optionally, you can download and build it from the sources. You have to retrieve the project sources by using one of the following way:
 ```bash
-$ go get -u github.com/eko/pihole-exporter
+$ go install github.com/eko/pihole-exporter@latest
 # or
 $ git clone https://github.com/eko/pihole-exporter.git
 ```


### PR DESCRIPTION
Updated the README.md 'From Source' section to reflect the latest Go standard from 'go get' to 'go install' with the correct URL for this project.

My current build of golang:

```
$ go version
go version go1.19.5 linux/amd64
```