### PR TITLE
bump golang to 1.20.1 to address  buildvcs=true failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG IMAGE=scratch
 ARG OS=linux
 ARG ARCH=amd64
 
-FROM golang:1.19.3-alpine3.15 as builder
+FROM golang:1.20.1-alpine3.17 as builder
 
 WORKDIR /go/src/github.com/eko/pihole-exporter
 COPY . .


### PR DESCRIPTION
The older golang:1.19.3-alpine3.15 as builder is failing, due to the go build error 'error obtaining VCS status: exit status 128'.

Bumping the builder image to golang:1.20.1-alpine3.17 fixes this golang build failure.