### PR TITLE
Teach pihole-exporter how to bind to a specific interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ scrape_configs:
 # WEBPASSWORD / api token defined on the PI-Hole interface at `/etc/pihole/setupVars.conf`
   -pihole_api_token string (optional)
 
+# Address to be used for the exporter
+  -bind_addr string (optional) (default "0.0.0.0")
+
 # Port to be used for the exporter
   -port string (optional) (default "9617")
 ```

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -24,6 +24,8 @@ type Config struct {
 	PIHolePort     uint16 `config:"pihole_port"`
 	PIHolePassword string `config:"pihole_password"`
 	PIHoleApiToken string `config:"pihole_api_token"`
+	BindAddr       string `config:"bind_addr"`
+	Port           uint16 `config:"port"`
 }
 
 type EnvConfig struct {
@@ -32,6 +34,7 @@ type EnvConfig struct {
 	PIHolePort     []uint16      `config:"pihole_port"`
 	PIHolePassword []string      `config:"pihole_password"`
 	PIHoleApiToken []string      `config:"pihole_api_token"`
+	BindAddr       string        `config:"bind_addr"`
 	Port           uint16        `config:"port"`
 	Timeout        time.Duration `config:"timeout"`
 }
@@ -43,6 +46,7 @@ func getDefaultEnvConfig() *EnvConfig {
 		PIHolePort:     []uint16{80},
 		PIHolePassword: []string{},
 		PIHoleApiToken: []string{},
+		BindAddr:       "0.0.0.0",
 		Port:           9617,
 		Timeout:        5 * time.Second,
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,10 +20,10 @@ type Server struct {
 
 // NewServer method initializes a new HTTP server instance and associates
 // the different routes that will be used by Prometheus (metrics) or for monitoring (readiness, liveness).
-func NewServer(port uint16, clients []*pihole.Client) *Server {
+func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 	mux := http.NewServeMux()
 	httpServer := &http.Server{
-		Addr:    ":" + strconv.Itoa(int(port)),
+		Addr:    addr + ":" + strconv.Itoa(int(port)),
 		Handler: mux,
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	clients := buildClients(clientConfigs, envConf)
 
-	s := server.NewServer(envConf.Port, clients)
+	s := server.NewServer(envConf.BindAddr, envConf.Port, clients)
 	go func() {
 		s.ListenAndServe()
 		close(serverDead)


### PR DESCRIPTION
## Description

Add an additional configuration option to support forcing pihole-exporter to bind to a specific address, such as localhost/127.0.0.1. The default behavior is to bind to all addresses/interfaces (0.0.0.0).

Closes #175

## Testing

I've performed only minimal testing of these changes; I'd be happy to take direction on more involved testing. Please let me know if there's additional validation you'd like me to perform.

The default behavior (i.e. -bind_addr not specified) looks like this:

```
zhengyi at vmbox in pihole-exporter-bindaddr on  add-bind-addr-support [?]
➜ ./pihole-exporter
INFO[0000] ------------------------------------
INFO[0000] -  PI-Hole exporter configuration  -
INFO[0000] ------------------------------------
INFO[0000] Go version: go1.18
INFO[0000] PIHoleProtocol : [http]
INFO[0000] PIHoleHostname : [127.0.0.1]
INFO[0000] PIHolePort : [80]
INFO[0000] BindAddr : 0.0.0.0
INFO[0000] Port : 9617
INFO[0000] Timeout : 5s
...
```

With the new option, we see this instead:

```
zhengyi at vmbox in pihole-exporter-bindaddr on  add-bind-addr-support [?] took 1m 34.0s
➜ ./pihole-exporter -bind_addr 127.0.0.1
INFO[0000] ------------------------------------
INFO[0000] -  PI-Hole exporter configuration  -
INFO[0000] ------------------------------------
INFO[0000] Go version: go1.18
INFO[0000] PIHoleProtocol : [http]
INFO[0000] PIHoleHostname : [127.0.0.1]
INFO[0000] PIHolePort : [80]
INFO[0000] BindAddr : 127.0.0.1
INFO[0000] Port : 9617
INFO[0000] Timeout : 5s
```

And we can see that the process is indeed bound specifically to localhost only:

```
zhengyi at vmbox in pihole-exporter-bindaddr on  add-bind-addr-support
➜ sudo ss -tnlp
[sudo] password for zhengyi:
State     Recv-Q    Send-Q       Local Address:Port       Peer Address:Port   Process
LISTEN    0         4096         127.0.0.53%lo:53              0.0.0.0:*       users:(("systemd-resolve",pid=961,fd=17))
LISTEN    0         4096             127.0.0.1:9617            0.0.0.0:*       users:(("pihole-exporter",pid=1161430,fd=4))
LISTEN    0         4096               0.0.0.0:5355            0.0.0.0:*       users:(("systemd-resolve",pid=961,fd=11))
LISTEN    0         128                0.0.0.0:22              0.0.0.0:*       users:(("sshd",pid=1599562,fd=3))
LISTEN    0         4096            127.0.0.54:53              0.0.0.0:*       users:(("systemd-resolve",pid=961,fd=19))
LISTEN    0         4096                     *:9100                  *:*       users:(("node_exporter",pid=4065634,fd=3))
LISTEN    0         4096                  [::]:5355               [::]:*       users:(("systemd-resolve",pid=961,fd=13))
LISTEN    0         128                   [::]:22                 [::]:*       users:(("sshd",pid=1599562,fd=4))
```