### PR TITLE
Update README.md; spurious comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If port, protocol and API token/password is the same for all instances, you can 
 
 ```
 $ docker run \
-  -e 'PIHOLE_PROTOCOL=,http" \
+  -e 'PIHOLE_PROTOCOL=http" \
   -e 'PIHOLE_HOSTNAME=192.168.1.2,192.168.1.3,192.168.1.4"' \
   -e "PIHOLE_API_TOKEN=$API_TOKEN" \
   -e "PIHOLE_PORT=8080" \


### PR DESCRIPTION
Spurious comma in the example for specifying environment variables targeting multiple endpoints, but with a singular config.