### PR TITLE
Add queries_last_10min metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ scrape_configs:
 | pihole_forward_destinations  | This represent the number of forward destinations requests made by Pi-hole by destination |
 | pihole_querytypes            | This represent the number of queries made by Pi-hole by type                              |
 | pihole_status                | This represent if Pi-hole is enabled                                                      |
+| queries_last_10min           | This represent the number of queries in the last full slot of 10 minutes                  |
 
 
 ## Pihole-Exporter Helm Chart

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -183,7 +183,7 @@ func (c Config) hostnameURL() string {
 
 // PIHoleStatsURL returns the stats url
 func (c Config) PIHoleStatsURL() string {
-	return c.hostnameURL() + "/admin/api.php?summaryRaw&overTimeData&topItems&recentItems&getQueryTypes&getForwardDestinations&getQuerySources&jsonForceObject"
+	return c.hostnameURL() + "/admin/api.php?summaryRaw&overTimeData&topItems&recentItems&getQueryTypes&getForwardDestinations&getQuerySources&overTimeData10mins&jsonForceObject"
 }
 
 // PIHoleLoginURL returns the login url

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -175,6 +175,16 @@ var (
 		},
 		[]string{"hostname"},
 	)
+
+	// QueriesLast10min - Number of queries in the last full slot of 10 minutes
+	QueriesLast10min = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "queries_last_10min",
+			Namespace: "pihole",
+			Help:      "Number of queries in the last full slot of 10 minutes",
+		},
+		[]string{"hostname"},
+	)
 )
 
 // Init initializes all Prometheus metrics made available by Pi-hole exporter.
@@ -196,6 +206,7 @@ func Init() {
 	initMetric("forward_destinations", ForwardDestinations)
 	initMetric("querytypes", QueryTypes)
 	initMetric("status", Status)
+	initMetric("queries_last_10min", QueriesLast10min)
 }
 
 func initMetric(name string, metric *prometheus.GaugeVec) {

--- a/internal/pihole/model.go
+++ b/internal/pihole/model.go
@@ -38,6 +38,7 @@ type Stats struct {
 	ForwardDestinations map[string]float64 `json:"forward_destinations"`
 	QueryTypes          map[string]float64 `json:"querytypes"`
 	Status              string             `json:"status"`
+	DomainsOverTime     map[int]int        `json:"domains_over_time"`
 }
 
 // ToString method returns a string of the current statistics struct.


### PR DESCRIPTION
This allows to have the same histogram that you see when you access your Pi-hole dashboard.
Adds 'overTimeData10mins' to the Pi-hole API request to provide the metric `queries_last_10min`.