### PR TITLE
Add pihole_ads_last_10min metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ $ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_api_token $API_TOKEN
 2019/05/09 20:19:52 New Prometheus metric registered: forward_destinations
 2019/05/09 20:19:52 New Prometheus metric registered: querytypes
 2019/05/09 20:19:52 New Prometheus metric registered: status
+2019/05/09 20:19:52 New Prometheus metric registered: queries_last_10min
+2019/05/09 20:19:52 New Prometheus metric registered: ads_last_10min
 2019/05/09 20:19:52 Starting HTTP server
 2019/05/09 20:19:54 New tick of statistics: 648 ads blocked / 66796 total DNS querie
 ...
@@ -224,6 +226,7 @@ scrape_configs:
 | pihole_querytypes            | This represent the number of queries made by Pi-hole by type                              |
 | pihole_status                | This represent if Pi-hole is enabled                                                      |
 | queries_last_10min           | This represent the number of queries in the last full slot of 10 minutes                  |
+| ads_last_10min               | This represent the number of ads in the last full slot of 10 minutes                      |
 
 
 ## Pihole-Exporter Helm Chart

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -185,6 +185,16 @@ var (
 		},
 		[]string{"hostname"},
 	)
+
+	// AdsLast10min - Number of ads in the last full slot of 10 minutes
+	AdsLast10min = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "ads_last_10min",
+			Namespace: "pihole",
+			Help:      "Number of ads in the last full slot of 10 minutes",
+		},
+		[]string{"hostname"},
+	)
 )
 
 // Init initializes all Prometheus metrics made available by Pi-hole exporter.
@@ -207,6 +217,7 @@ func Init() {
 	initMetric("querytypes", QueryTypes)
 	initMetric("status", Status)
 	initMetric("queries_last_10min", QueriesLast10min)
+	initMetric("ads_last_10min", AdsLast10min)
 }
 
 func initMetric(name string, metric *prometheus.GaugeVec) {

--- a/internal/pihole/model.go
+++ b/internal/pihole/model.go
@@ -39,6 +39,7 @@ type Stats struct {
 	QueryTypes          map[string]float64 `json:"querytypes"`
 	Status              string             `json:"status"`
 	DomainsOverTime     map[int]int        `json:"domains_over_time"`
+	AdsOverTime         map[int]int        `json:"ads_over_time"`
 }
 
 // ToString method returns a string of the current statistics struct.


### PR DESCRIPTION
Hi there! First of all, thanks a lot for the exporter!

By reading the pihole `ads_over_time` API metric, **I have implemented a new metric `pihole_ads_last_10min`**.

With this new metric ̣–along with the existing `pihole_queries_last_10min`– the histogram graph pihole offers in its admin (Permitted DNS vs Blocked DNS) can be fully recreated in Prometheus/Grafana :)

![image](https://github.com/user-attachments/assets/33e9131a-dd0e-4ff2-a509-37d76d28f59c)

Please let me know what you think!

Thanks!