### PR TITLE
feat: support TLS skip verification, add debug mode, and harden metrics scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ $ API_TOKEN=$(awk -F= -v key="WEBPASSWORD" '$1==key {print $2}' /etc/pihole/setu
 $ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_password $API_TOKEN
 ```
 
+#### Debug logging
+
+You can enable verbose output either by environment variable or CLI flag:
+
+Both options set logrus to `debug` level (shown below); otherwise the exporter logs at `info`.
+
+___
+
 ```bash
 2019/05/09 20:19:52 ------------------------------------
 2019/05/09 20:19:52 -  Pi-hole exporter configuration  -
@@ -172,7 +180,7 @@ $ ./pihole_exporter -pihole_hostname 192.168.1.10 -pihole_password $API_TOKEN
 2019/05/09 20:19:52 New Prometheus metric registered: queries_last_10min
 2019/05/09 20:19:52 New Prometheus metric registered: ads_last_10min
 2019/05/09 20:19:52 Starting HTTP server
-2019/05/09 20:19:54 New tick of statistics: 648 ads blocked / 66796 total DNS querie
+2019/05/09 20:19:54 New tick of statistics: 648 ads blocked / 66796 total DNS queries
 ...
 ```
 
@@ -208,7 +216,21 @@ scrape_configs:
 
 # Port to be used for the exporter
   -port string (optional) (default "9617")
+
+# Disabling TLS verification
+  disabling TLS verification accepts any certificate 
+    and skips hostname checks - 
+    do NOT use on untrusted networks!!
+
+  -skip_tls_verification true
+
+# Enable debug (verbose) output
+  -debug
 ```
+
+
+
+
 
 ## Available Prometheus metrics
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -19,23 +19,25 @@ import (
 
 // Config is the exporter CLI configuration.
 type Config struct {
-	PIHoleProtocol string `config:"pihole_protocol"`
-	PIHoleHostname string `config:"pihole_hostname"`
-	PIHolePort     uint16 `config:"pihole_port"`
-	PIHolePassword string `config:"pihole_password"`
-	BindAddr       string `config:"bind_addr"`
-	Port           uint16 `config:"port"`
+	PIHoleProtocol      string `config:"pihole_protocol"`
+	PIHoleHostname      string `config:"pihole_hostname"`
+	PIHolePort          uint16 `config:"pihole_port"`
+	PIHolePassword      string `config:"pihole_password"`
+	BindAddr            string `config:"bind_addr"`
+	Port                uint16 `config:"port"`
+	SkipTLSVerification bool `config:"skip_tls_verification"`
 }
 
 type EnvConfig struct {
-	PIHoleProtocol []string      `config:"pihole_protocol"`
-	PIHoleHostname []string      `config:"pihole_hostname"`
-	PIHolePort     []uint16      `config:"pihole_port"`
-	PIHolePassword []string      `config:"pihole_password"`
-	BindAddr       string        `config:"bind_addr"`
-	Port           uint16        `config:"port"`
-	Timeout        time.Duration `config:"timeout"`
-}
+	PIHoleProtocol      []string      `config:"pihole_protocol"`
+	PIHoleHostname      []string      `config:"pihole_hostname"`
+	PIHolePort          []uint16      `config:"pihole_port"`
+	PIHolePassword      []string      `config:"pihole_password"`
+	BindAddr            string        `config:"bind_addr"`
+	Port                uint16        `config:"port"`
+	Timeout             time.Duration `config:"timeout"`
+	SkipTLSVerification bool `config:"skip_tls_verification"`
+	}
 
 func getDefaultEnvConfig() *EnvConfig {
 	return &EnvConfig{
@@ -46,6 +48,7 @@ func getDefaultEnvConfig() *EnvConfig {
 		BindAddr:       "0.0.0.0",
 		Port:           9617,
 		Timeout:        5 * time.Second,
+		SkipTLSVerification: false,
 	}
 }
 
@@ -61,7 +64,7 @@ func Load() (*EnvConfig, []Config, error) {
 	cfg := getDefaultEnvConfig()
 	err := loader.Load(context.Background(), cfg)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error returned when passing config into loader.Load(): %v", err)
 	}
 
 	cfg.show()

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -7,21 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	PIHOLE_HOSTNAME      = "PIHOLE_HOSTNAME"
-	PIHOLE_PORT          = "PIHOLE_PORT"
-	PIHOLE_ADMIN_CONTEXT = "PIHOLE_ADMIN_CONTEXT"
-	PIHOLE_PASSWORD      = "PIHOLE_PASSWORD"
-	PIHOLE_PROTOCOL      = "PIHOLE_PROTOCOL"
-)
-
-type EnvInitiazlier func(*testing.T)
-
-type TestCase struct {
-	Name        string
-	Initializer EnvInitiazlier
-}
-
 func TestSplitDefault(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -231,5 +231,5 @@ func Init() {
 
 func initMetric(name string, metric *prometheus.GaugeVec) {
 	prometheus.MustRegister(metric)
-	log.Info("New Prometheus metric registered: ", name)
+	log.Debugf("New Prometheus metric registered: %s", name)
 }

--- a/internal/pihole/api_client.go
+++ b/internal/pihole/api_client.go
@@ -32,7 +32,7 @@ type authResponse struct {
 // NewAPIClient initializes and returns a new APIClient with optional TLS verification disabling.
 func NewAPIClient(baseURL string, password string, timeout time.Duration, disableTLSVerification bool) *APIClient {
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: skipTLSmatchSNI,
+		InsecureSkipVerify: disableTLSVerification,
 	}
 	
 	transport := &http.Transport{

--- a/internal/pihole/api_client.go
+++ b/internal/pihole/api_client.go
@@ -29,13 +29,22 @@ type authResponse struct {
 	} `json:"session"`
 }
 
-// NewAPIClient initializes and returns a new APIClient.
-func NewAPIClient(baseURL, password string, timeout time.Duration) *APIClient {
+// NewAPIClient initializes and returns a new APIClient with optional TLS verification disabling.
+func NewAPIClient(baseURL string, password string, timeout time.Duration, disableTLSVerification bool) *APIClient {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: skipTLSmatchSNI,
+	}
+	
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
 	return &APIClient{
 		BaseURL:  baseURL,
 		password: password,
 		Client: &http.Client{
-			Timeout: timeout,
+			Timeout:   timeout,
+			Transport: transport,
 		},
 	}
 }

--- a/internal/pihole/api_client_test.go
+++ b/internal/pihole/api_client_test.go
@@ -1,0 +1,43 @@
+package pihole_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eko/pihole-exporter/internal/pihole"
+)
+
+// transport returns the transport of the client
+func transport(t *testing.T, c *pihole.APIClient) *http.Transport {
+	t.Helper()
+	tr, ok := c.Client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport not *http.Transport")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatalf("nil TLSClientConfig")
+	}
+	return tr
+}
+
+// TestNewAPIClient_TLSVerification tests the TLS verification of the client
+func TestNewAPIClient_TLSVerification(t *testing.T) {
+	tests := []struct {
+		name             string
+		skipVerify       bool
+		wantInsecureSkip bool
+	}{
+		{"disabled", true, true},
+		{"enabled", false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := pihole.NewAPIClient("https://cloudflare.com", "", time.Second, tc.skipVerify)
+			if got := transport(t, c).TLSClientConfig.InsecureSkipVerify; got != tc.wantInsecureSkip {
+				t.Errorf("InsecureSkipVerify = %v, want %v", got, tc.wantInsecureSkip)
+			}
+		})
+	}
+}

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -3,7 +3,6 @@ package pihole
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -59,15 +58,14 @@ type Client struct {
 func NewClient(config *config.Config, envConfig *config.EnvConfig) *Client {
 	err := config.Validate()
 	if err != nil {
-		log.Error(err)
-		os.Exit(1)
+		log.Fatalf("err: couldn't validate passed Config: %v", err)
 	}
 
-	log.Printf("Creating client with config %s\n", config)
+	log.Printf("Creating client with config %+v\n", config)
 
 	return &Client{
 		config:    config,
-		apiClient: *NewAPIClient(fmt.Sprintf("%s://%s:%d", config.PIHoleProtocol, config.PIHoleHostname, config.PIHolePort), config.PIHolePassword, envConfig.Timeout),
+		apiClient: *NewAPIClient(fmt.Sprintf("%s://%s:%d", config.PIHoleProtocol, config.PIHoleHostname, config.PIHolePort), config.PIHolePassword, envConfig.Timeout, config.SkipTLSVerification),
 		Status:    make(chan *ClientChannel, 1),
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,8 +3,8 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eko/pihole-exporter/internal/pihole"
@@ -23,7 +23,7 @@ type Server struct {
 func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 	mux := http.NewServeMux()
 	httpServer := &http.Server{
-		Addr:    addr + ":" + strconv.Itoa(int(port)),
+		Addr:    fmt.Sprintf("%s:%d", addr, port),
 		Handler: mux,
 	}
 
@@ -32,16 +32,59 @@ func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 	}
 
 	mux.HandleFunc("/metrics", func(writer http.ResponseWriter, request *http.Request) {
-		log.Printf("request.Header: %v\n", request.Header)
+		log.Debugf("request.Header: %+v\n", request.Header)
+
+		// Use a WaitGroup to track goroutines
+		var wg sync.WaitGroup
+		// Create a context with timeout for metrics collection
+		ctx, cancel := context.WithTimeout(request.Context(), 10*time.Second)
+		defer cancel()
+
+		// Channel to collect results from goroutines
+		resultChan := make(chan *pihole.ClientChannel, len(clients))
 
 		for _, client := range clients {
-			go client.CollectMetricsAsync(writer, request)
+			wg.Add(1)
+			go func(c *pihole.Client) {
+				defer wg.Done()
+
+				// Create a channel for this goroutine
+				doneChan := make(chan struct{})
+
+				go func() {
+					c.CollectMetricsAsync(writer, request)
+					close(doneChan)
+				}()
+
+				// Wait for either completion or timeout
+				select {
+				case <-doneChan:
+					// Normal completion, status will be read below
+				case <-ctx.Done():
+					// Timeout occurred
+					resultChan <- &pihole.ClientChannel{
+						Status: pihole.MetricsCollectionTimeout,
+						Err:    fmt.Errorf("metrics collection from %s timed out", c.GetHostname()),
+					}
+					// We need to read from the Status channel to prevent blocking
+					go func() {
+						<-c.Status // Discard the result when it eventually comes
+					}()
+				}
+			}(client)
 		}
 
+		// Start a goroutine to close resultChan when all goroutines are done
+		go func() {
+			wg.Wait()
+			close(resultChan)
+		}()
+
+		// Read all results
 		for _, client := range clients {
 			status := <-client.Status
-			if status.Status == pihole.MetricsCollectionError {
-				log.Printf("An error occured while contacting %s: %s", client.GetHostname(), status.Err.Error())
+			if status.Status != pihole.MetricsCollectionSuccess {
+				log.Warnf("An error occurred while contacting %s: %+v\n", client.GetHostname(), status.Err)
 			}
 		}
 
@@ -55,13 +98,8 @@ func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 }
 
 // ListenAndServe method serves HTTP requests.
-func (s *Server) ListenAndServe() {
-	log.Println("Starting HTTP server")
-
-	err := s.httpServer.ListenAndServe()
-	if err != nil {
-		log.Printf("Failed to start serving HTTP requests: %v", err)
-	}
+func (s *Server) ListenAndServe() error {
+	return s.httpServer.ListenAndServe()
 }
 
 // Stop method stops the HTTP server (so the exporter become unavailable).
@@ -72,6 +110,7 @@ func (s *Server) Stop() {
 	s.httpServer.Shutdown(ctx)
 }
 
+// handleMetrics, helper function is unused
 func (s *Server) handleMetrics(clients []*pihole.Client) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
 		errors := make([]string, 0)
@@ -79,7 +118,7 @@ func (s *Server) handleMetrics(clients []*pihole.Client) http.HandlerFunc {
 		for _, client := range clients {
 			if err := client.CollectMetrics(writer, request); err != nil {
 				errors = append(errors, err.Error())
-				fmt.Printf("Error %s\n", err)
+				log.Warnf("error collecting metrics from %s: %+v\n", client.GetHostname(), err)
 			}
 		}
 
@@ -95,11 +134,11 @@ func (s *Server) handleMetrics(clients []*pihole.Client) http.HandlerFunc {
 
 func (s *Server) readinessHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		status := http.StatusNotFound
 		if s.isReady() {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
+			status = http.StatusOK
 		}
+		w.WriteHeader(status)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"errors"
+	"flag"
+	"net/http"
+	"os"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/eko/pihole-exporter/config"
@@ -10,46 +16,76 @@ import (
 	"github.com/xonvanetta/shutdown/pkg/shutdown"
 )
 
+var (
+	debugFlag = flag.Bool("debug", false, "enable debug logging")
+)
+
 func main() {
+	flag.Parse()
+
+	debugEnv := strings.ToLower(os.Getenv("DEBUG"))
+	debug := *debugFlag || debugEnv == "true" || debugEnv == "1"
+
+	configureLogger(debug)
+
 	envConf, clientConfigs, err := config.Load()
 	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
+		log.Fatalf("failed to load configuration: %v", err)
 	}
+
+	log.Infof("starting pihole-exporter")
 
 	metrics.Init()
 
-	serverDead := make(chan struct{})
-
 	clients := buildClients(clientConfigs, envConf)
+	defer closeClients(clients)
 
-	s := server.NewServer(envConf.BindAddr, envConf.Port, clients)
-	go func() {
-		s.ListenAndServe()
-		close(serverDead)
-	}()
+	srv := server.NewServer(envConf.BindAddr, envConf.Port, clients)
 
+	// Context that is cancelled on SIGINT/SIGTERM.
 	ctx := shutdown.Context()
 
 	go func() {
 		<-ctx.Done()
-		s.Stop()
+		srv.Stop()
 	}()
 
-	select {
-	case <-ctx.Done():
-	case <-serverDead:
+	if err := srv.ListenAndServe(); err != nil {
+		// Ignore the expected error when the server is closed gracefully.
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("HTTP server error: %v", err)
+		}
 	}
 
 	log.Info("pihole-exporter HTTP server stopped")
 }
 
+// configureLogger sets the global logrus level and formatter.
+func configureLogger(debug bool) {
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+}
+
+// buildClients constructs a slice of Pi‑hole API clients from configuration.
 func buildClients(clientConfigs []config.Config, envConfig *config.EnvConfig) []*pihole.Client {
 	clients := make([]*pihole.Client, 0, len(clientConfigs))
 	for i := range clientConfigs {
-		clientConfig := &clientConfigs[i]
-
-		client := pihole.NewClient(clientConfig, envConfig)
-		clients = append(clients, client)
+		// Use the index variable rather than the for‑range copy to avoid the pointer‑to‑loop‑variable pitfall.
+		cfg := &clientConfigs[i]
+		clients = append(clients, pihole.NewClient(cfg, envConfig))
 	}
 	return clients
+}
+
+// closeClients closes each client, logging progress.
+func closeClients(clients []*pihole.Client) {
+	log.Info("closing clients…")
+	for _, c := range clients {
+		c.Close()
+	}
+	log.Info("all clients closed")
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/eko/pihole-exporter/config"
 	"github.com/eko/pihole-exporter/internal/metrics"
@@ -13,7 +13,7 @@ import (
 func main() {
 	envConf, clientConfigs, err := config.Load()
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
 	metrics.Init()
@@ -40,7 +40,7 @@ func main() {
 	case <-serverDead:
 	}
 
-	log.Println("pihole-exporter HTTP server stopped")
+	log.Info("pihole-exporter HTTP server stopped")
 }
 
 func buildClients(clientConfigs []config.Config, envConfig *config.EnvConfig) []*pihole.Client {


### PR DESCRIPTION
This PR started as a small feature request - allowing users to skip TLS certificate verification when connecting to Pi-hole over HTTPS (#260).

Along the way, it evolved into a broader improvement:

---

## ✨ What's new

- **TLS skip verification**  
  - Config option: `skip_tls_verification` (YAML or CLI)  
  - Passed through to `http.Transport.TLSClientConfig.InsecureSkipVerify`
  - Warning logged if enabled (only for internal/trusted use)

- **Improved `/metrics` handler**  
  - Adds a `10s` timeout per scrape using `context.WithTimeout`  
  - Prevents goroutine leaks by draining client status channels  
  - Uses `sync.WaitGroup` and `doneChan` per client  
  - Returns `MetricsCollectionTimeout` for hung backends

- **Verbose logging mode**  
  - Enabled via `--debug` flag or `DEBUG=1` env var  
  - Uses `logrus.Debugf` throughout  
  - More consistent log structure

- **Config safety improvements**  
  - Redacts `PIHolePassword` from `fmt.Stringer`  
  - More idiomatic `Validate()` error messages

- **Tests**  
  - Unit test for TLS verification behavior  
  - Limits HTTP response size (`1MB`) in `io.ReadAll` for DoS safety

- **Docs**  
  - README updated with new flag, YAML example, and **warning**  
  - `debug` section added

