### PR TITLE
fix(config): prevent recursion in String() by using %p for pointer

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -82,7 +82,7 @@ func Load() (*EnvConfig, []Config, error) {
 // String implements fmt.Stringer with a modern strings.Builder implementation.
 func (c *Config) String() string {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("<Config@%X ", c))
+	b.WriteString(fmt.Sprintf("<Config@%p ", c))
 	ref := reflect.ValueOf(c).Elem()
 	for i := 0; i < ref.NumField(); i++ {
 		tf := ref.Type().Field(i)


### PR DESCRIPTION
- Using %X in Sprintf invoked the String method recusively on *Config.
- Swap w/ %p to avoid using ** or unsafe.  prints pointer address w/o invoking String().