### PR TITLE
add ca-certs to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM $IMAGE
 LABEL name="pihole-exporter"
 
 WORKDIR /root/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/eko/pihole-exporter/binary pihole-exporter
 
 CMD ["./pihole-exporter"]


### PR DESCRIPTION
the container image is missing ca-certs since it's built from `SCRATCH` therefor any pihole endpoint using (valid/letsencrypt) TLS-certs will fail.

This PR copies those ca-certs from the `alpine` build stage to the final image