### PR TITLE
[ WIP ] Add `pihole_queries_total` counter metric via History API

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,11 +6,11 @@ import (
 )
 
 var (
-	WindowQueries = prometheus.NewGaugeVec(
+	Queries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name:      "window_queries",
+			Name:      "queries_total",
 			Namespace: "pihole",
-			Help:      "This represent the number of queries made over the defined window",
+			Help:      "This represent the total number of queries",
 		},
 		[]string{"hostname", "type"},
 	)
@@ -216,7 +216,7 @@ var (
 
 // Init initializes all Prometheus metrics made available by Pi-hole exporter.
 func Init() {
-	initMetric("window_queries", WindowQueries)
+	initMetric("queries_total", Queries)
 	initMetric("domains_blocked", DomainsBlocked)
 	initMetric("dns_queries_today", DNSQueriesToday)
 	initMetric("ads_blocked_today", AdsBlockedToday)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,7 +12,7 @@ var (
 			Namespace: "pihole",
 			Help:      "This represent the number of queries made over the defined window",
 		},
-		[]string{"hostname", "type", "timestamp"},
+		[]string{"hostname", "type"},
 	)
 
 	// DomainsBlocked - The number of domains being blocked by Pi-hole.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,6 +6,15 @@ import (
 )
 
 var (
+	WindowQueries = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "window_queries",
+			Namespace: "pihole",
+			Help:      "This represent the number of queries made over the defined window",
+		},
+		[]string{"hostname", "type", "timestamp"},
+	)
+
 	// DomainsBlocked - The number of domains being blocked by Pi-hole.
 	DomainsBlocked = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -207,6 +216,7 @@ var (
 
 // Init initializes all Prometheus metrics made available by Pi-hole exporter.
 func Init() {
+	initMetric("window_queries", WindowQueries)
 	initMetric("domains_blocked", DomainsBlocked)
 	initMetric("dns_queries_today", DNSQueriesToday)
 	initMetric("ads_blocked_today", AdsBlockedToday)

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -101,18 +101,39 @@ func (c *Client) GetHostname() string {
 }
 
 func (c *Client) setMetrics(queryHistoryResponse *QueryHistoryResponse, stats *StatsSummary, blockedDomains *TopDomains, permittedDomains *TopDomains, clients *[]PiHoleClient, upstreams *Upstreams, piHoleStatus *BlockingStatus) {
-	now := time.Now().Unix()
-	boundary := (now - (now % 300)) - 300
 
-	for _, entry := range queryHistoryResponse.History {
-		if entry.Timestamp == boundary {
-			// metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "total")
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "blocked")
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "cached")
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "forwarded")
-			break
+	// go thru each entry in queryHistoryResponse.History and add the metrics.
+	lastQuery := getLastQueryEntry()
+	total := lastQuery.Total
+	cached := lastQuery.Cached
+	blocked := lastQuery.Blocked
+	forwarded := lastQuery.Forwarded
+
+	// if response history is empty, we skip processing
+	if len(queryHistoryResponse.History) > 0 {
+		for _, entry := range queryHistoryResponse.History {
+			total += float64(entry.Total)
+			cached += float64(entry.Cached)
+			blocked += float64(entry.Blocked)
+			forwarded += float64(entry.Forwarded)
+			log.Infof("Values - Total: %.0f, Cached: %.0f, Blocked: %.0f, Forwarded: %.0f", entry.Total, entry.Cached, entry.Blocked, entry.Forwarded)
 		}
+
+		// Update last query metrics
+		lastQuery.Timestamp = time.Now().Unix() - 60
+		lastQuery.Total = total
+		lastQuery.Cached = cached
+		lastQuery.Blocked = blocked
+		lastQuery.Forwarded = forwarded
+		setLastQueryEntry(lastQuery)
 	}
+
+	log.Infof("Window Queries - Total: %.0f, Cached: %.0f, Blocked: %.0f, Forwarded: %.0f", total, cached, blocked, forwarded)
+
+	// metrics.Queries.WithLabelValues(c.config.PIHoleHostname, "total").Set(float64(entry.Total))
+	metrics.Queries.WithLabelValues(c.config.PIHoleHostname, "blocked").Set(float64(blocked))
+	metrics.Queries.WithLabelValues(c.config.PIHoleHostname, "cached").Set(float64(cached))
+	metrics.Queries.WithLabelValues(c.config.PIHoleHostname, "forwarded").Set(float64(total - cached - blocked))
 
 	metrics.DomainsBlocked.WithLabelValues(c.config.PIHoleHostname).Set(float64(stats.Gravity.DomainsBeingBlocked))
 	metrics.DNSQueriesToday.WithLabelValues(c.config.PIHoleHostname).Set(float64(stats.Queries.Total))
@@ -179,7 +200,12 @@ func (c *Client) getStatistics() (*QueryHistoryResponse, *StatsSummary, *TopDoma
 	var upstreams Upstreams
 	var piHoleStatus BlockingStatus
 
-	err := c.apiClient.FetchData("/api/history", &queryHistoryResponse)
+	// Read LAST_QUERY_DATA env variable using helper
+	// run one minute back in time
+	now := time.Now().Unix() - 60
+	lastQuery := getLastQueryEntry()
+	log.Infof("URL = /api/history/database?from=%d&until=%d", lastQuery.Timestamp, now)
+	err := c.apiClient.FetchData(fmt.Sprintf("/api/history/database?from=%d&until=%d", lastQuery.Timestamp, now), &queryHistoryResponse)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching query history: %w", err)
 	}

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -3,6 +3,7 @@ package pihole
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -76,8 +77,8 @@ func (c *Client) String() string {
 
 func (c *Client) CollectMetricsAsync(writer http.ResponseWriter, request *http.Request) {
 	log.Debugf("Collecting from %s", c.config.PIHoleHostname)
-	if stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus, err := c.getStatistics(); err == nil {
-		c.setMetrics(stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus)
+	if queryHistoryResponse, stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus, err := c.getStatistics(); err == nil {
+		c.setMetrics(queryHistoryResponse, stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus)
 		c.Status <- &ClientChannel{Status: MetricsCollectionSuccess, Err: nil}
 		log.Debugf("New tick of statistics from %s: %s", c.config.PIHoleHostname, stats)
 	} else {
@@ -86,11 +87,11 @@ func (c *Client) CollectMetricsAsync(writer http.ResponseWriter, request *http.R
 }
 
 func (c *Client) CollectMetrics(writer http.ResponseWriter, request *http.Request) error {
-	stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus, err := c.getStatistics()
+	queryHistoryResponse, stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus, err := c.getStatistics()
 	if err != nil {
 		return err
 	}
-	c.setMetrics(stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus)
+	c.setMetrics(queryHistoryResponse, stats, blockedDomains, permittedDomains, clients, upstreams, piHoleStatus)
 	log.Debugf("New tick of statistics from %s: %s", c.config.PIHoleHostname, stats)
 	return nil
 }
@@ -99,7 +100,20 @@ func (c *Client) GetHostname() string {
 	return c.config.PIHoleHostname
 }
 
-func (c *Client) setMetrics(stats *StatsSummary, blockedDomains *TopDomains, permittedDomains *TopDomains, clients *[]PiHoleClient, upstreams *Upstreams, piHoleStatus *BlockingStatus) {
+func (c *Client) setMetrics(queryHistoryResponse *QueryHistoryResponse, stats *StatsSummary, blockedDomains *TopDomains, permittedDomains *TopDomains, clients *[]PiHoleClient, upstreams *Upstreams, piHoleStatus *BlockingStatus) {
+	now := time.Now().Unix()
+	boundary := (now - (now % 300)) - 300
+
+	for _, entry := range queryHistoryResponse.History {
+		if entry.Timestamp == boundary {
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "total", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Total))
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "blocked", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Blocked))
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "cached", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Cached))
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "forwarded", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Forwarded))
+			break
+		}
+	}
+
 	metrics.DomainsBlocked.WithLabelValues(c.config.PIHoleHostname).Set(float64(stats.Gravity.DomainsBeingBlocked))
 	metrics.DNSQueriesToday.WithLabelValues(c.config.PIHoleHostname).Set(float64(stats.Queries.Total))
 	metrics.AdsBlockedToday.WithLabelValues(c.config.PIHoleHostname).Set(float64(stats.Queries.Blocked))
@@ -155,7 +169,8 @@ func (c *Client) setMetrics(stats *StatsSummary, blockedDomains *TopDomains, per
 	}
 }
 
-func (c *Client) getStatistics() (*StatsSummary, *TopDomains, *TopDomains, *[]PiHoleClient, *Upstreams, *BlockingStatus, error) {
+func (c *Client) getStatistics() (*QueryHistoryResponse, *StatsSummary, *TopDomains, *TopDomains, *[]PiHoleClient, *Upstreams, *BlockingStatus, error) {
+	var queryHistoryResponse QueryHistoryResponse
 	var statsSummary StatsSummary
 	var permittedDomains TopDomains
 	var blockedDomains TopDomains
@@ -164,42 +179,47 @@ func (c *Client) getStatistics() (*StatsSummary, *TopDomains, *TopDomains, *[]Pi
 	var upstreams Upstreams
 	var piHoleStatus BlockingStatus
 
-	err := c.apiClient.FetchData("/api/stats/summary", &statsSummary)
+	err := c.apiClient.FetchData("/api/history", &queryHistoryResponse)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching stats summary: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching query history: %w", err)
+	}
+
+	err = c.apiClient.FetchData("/api/stats/summary", &statsSummary)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching stats summary: %w", err)
 	}
 
 	err = c.apiClient.FetchData("/api/stats/top_domains?blocked=true&count=10", &blockedDomains)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching blocked domains: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching blocked domains: %w", err)
 	}
 	err = c.apiClient.FetchData("/api/stats/top_domains?blocked=false&count=10", &permittedDomains)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching permitted domains: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching permitted domains: %w", err)
 	}
 
 	err = c.apiClient.FetchData("/api/stats/top_clients?blocked=true&count=10", &blockedClients)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching blocked clients: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching blocked clients: %w", err)
 	}
 	err = c.apiClient.FetchData("/api/stats/top_clients?blocked=false&count=10", &permittedClients)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching permitted clients: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching permitted clients: %w", err)
 	}
 
 	clients := MergeClients(permittedClients.Clients, blockedClients.Clients)
 
 	err = c.apiClient.FetchData("/api/stats/upstreams", &upstreams)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching upstream stats: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching upstream stats: %w", err)
 	}
 
 	err = c.apiClient.FetchData("/api/dns/blocking", &piHoleStatus)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching status: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("error fetching status: %w", err)
 	}
 
-	return &statsSummary, &blockedDomains, &permittedDomains, &clients, &upstreams, &piHoleStatus, nil
+	return &queryHistoryResponse, &statsSummary, &blockedDomains, &permittedDomains, &clients, &upstreams, &piHoleStatus, nil
 }
 
 // Close cleans up resources used by the client

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -106,10 +106,10 @@ func (c *Client) setMetrics(queryHistoryResponse *QueryHistoryResponse, stats *S
 
 	for _, entry := range queryHistoryResponse.History {
 		if entry.Timestamp == boundary {
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "total", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Total))
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "blocked", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Blocked))
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "cached", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Cached))
-			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "forwarded", fmt.Sprintf("%d", entry.Timestamp)).Set(float64(entry.Forwarded))
+			// metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "total")
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "blocked")
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "cached")
+			metrics.WindowQueries.WithLabelValues(c.config.PIHoleHostname, "forwarded")
 			break
 		}
 	}

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -103,7 +103,7 @@ func (c *Client) GetHostname() string {
 func (c *Client) setMetrics(queryHistoryResponse *QueryHistoryResponse, stats *StatsSummary, blockedDomains *TopDomains, permittedDomains *TopDomains, clients *[]PiHoleClient, upstreams *Upstreams, piHoleStatus *BlockingStatus) {
 
 	// go thru each entry in queryHistoryResponse.History and add the metrics.
-	lastQuery := getLastQueryEntry()
+	lastQuery := getLastQueryEntry(c.config.PIHoleHostname)
 	total := lastQuery.Total
 	cached := lastQuery.Cached
 	blocked := lastQuery.Blocked
@@ -125,7 +125,7 @@ func (c *Client) setMetrics(queryHistoryResponse *QueryHistoryResponse, stats *S
 		lastQuery.Cached = cached
 		lastQuery.Blocked = blocked
 		lastQuery.Forwarded = forwarded
-		setLastQueryEntry(lastQuery)
+		setLastQueryEntry(lastQuery, c.config.PIHoleHostname)
 	}
 
 	log.Infof("Window Queries - Total: %.0f, Cached: %.0f, Blocked: %.0f, Forwarded: %.0f", total, cached, blocked, forwarded)
@@ -203,7 +203,7 @@ func (c *Client) getStatistics() (*QueryHistoryResponse, *StatsSummary, *TopDoma
 	// Read LAST_QUERY_DATA env variable using helper
 	// run one minute back in time
 	now := time.Now().Unix() - 60
-	lastQuery := getLastQueryEntry()
+	lastQuery := getLastQueryEntry(c.config.PIHoleHostname)
 	log.Infof("URL = /api/history/database?from=%d&until=%d", lastQuery.Timestamp, now)
 	err := c.apiClient.FetchData(fmt.Sprintf("/api/history/database?from=%d&until=%d", lastQuery.Timestamp, now), &queryHistoryResponse)
 	if err != nil {

--- a/internal/pihole/get_last_query_entry.go
+++ b/internal/pihole/get_last_query_entry.go
@@ -1,0 +1,49 @@
+package pihole
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// getLastQueryEntry reads the LAST_QUERY_DATA env variable and parses it as QueryHistoryEntry, or returns zero value if not set or invalid.
+func getLastQueryEntry() QueryHistoryEntry {
+	var lastQuery QueryHistoryEntry
+
+	// run one minute back in time
+	now := time.Now().Unix() - 60
+	var defaultLastQuery = QueryHistoryEntry{
+		Timestamp: now - 60,
+		Total:     0,
+		Cached:    0,
+		Blocked:   0,
+		Forwarded: 0,
+	}
+
+	lastQueryStr := os.Getenv("LAST_QUERY_DATA")
+	if lastQueryStr != "" {
+		if err := json.Unmarshal([]byte(lastQueryStr), &lastQuery); err != nil {
+			log.Infof("Failed to parse LAST_QUERY_DATA: %v", err)
+			setLastQueryEntry(defaultLastQuery)
+			return defaultLastQuery
+		}
+		return lastQuery
+	}
+	setLastQueryEntry(defaultLastQuery)
+	return defaultLastQuery
+}
+
+func setLastQueryEntry(entry QueryHistoryEntry) {
+	entryBytes, err := json.Marshal(entry)
+	if err != nil {
+		log.Infof("Failed to marshal last query entry: %v", err)
+		return
+	}
+	if err := os.Setenv("LAST_QUERY_DATA", string(entryBytes)); err != nil {
+		log.Infof("Failed to set LAST_QUERY_DATA env variable: %v", err)
+	}
+
+	log.Infof("Last Query Timestamp %d", entry.Timestamp)
+}

--- a/internal/pihole/get_last_query_entry.go
+++ b/internal/pihole/get_last_query_entry.go
@@ -9,7 +9,7 @@ import (
 )
 
 // getLastQueryEntry reads the LAST_QUERY_DATA env variable and parses it as QueryHistoryEntry, or returns zero value if not set or invalid.
-func getLastQueryEntry() QueryHistoryEntry {
+func getLastQueryEntry(hostname string) QueryHistoryEntry {
 	var lastQuery QueryHistoryEntry
 
 	// run one minute back in time
@@ -22,28 +22,28 @@ func getLastQueryEntry() QueryHistoryEntry {
 		Forwarded: 0,
 	}
 
-	lastQueryStr := os.Getenv("LAST_QUERY_DATA")
+	lastQueryStr := os.Getenv("LAST_QUERY_DATA_" + hostname)
 	if lastQueryStr != "" {
 		if err := json.Unmarshal([]byte(lastQueryStr), &lastQuery); err != nil {
 			log.Infof("Failed to parse LAST_QUERY_DATA: %v", err)
-			setLastQueryEntry(defaultLastQuery)
+			setLastQueryEntry(defaultLastQuery, hostname)
 			return defaultLastQuery
 		}
 		return lastQuery
 	}
-	setLastQueryEntry(defaultLastQuery)
+	setLastQueryEntry(defaultLastQuery, hostname)
 	return defaultLastQuery
 }
 
-func setLastQueryEntry(entry QueryHistoryEntry) {
+func setLastQueryEntry(entry QueryHistoryEntry, hostname string) {
 	entryBytes, err := json.Marshal(entry)
 	if err != nil {
 		log.Infof("Failed to marshal last query entry: %v", err)
 		return
 	}
-	if err := os.Setenv("LAST_QUERY_DATA", string(entryBytes)); err != nil {
+	if err := os.Setenv("LAST_QUERY_DATA_"+hostname, string(entryBytes)); err != nil {
 		log.Infof("Failed to set LAST_QUERY_DATA env variable: %v", err)
 	}
 
-	log.Infof("Last Query Timestamp %d", entry.Timestamp)
+	log.Infof("Last Query Timestamp for hostname %s will be %d", hostname, entry.Timestamp)
 }

--- a/internal/pihole/model.go
+++ b/internal/pihole/model.go
@@ -2,6 +2,21 @@ package pihole
 
 import "fmt"
 
+// QueryHistoryEntry represents a single entry in the query history.
+type QueryHistoryEntry struct {
+	Timestamp int64 `json:"timestamp"`
+	Total     int   `json:"total"`
+	Cached    int   `json:"cached"`
+	Blocked   int   `json:"blocked"`
+	Forwarded int   `json:"forwarded"`
+}
+
+// QueryHistoryResponse represents the response containing query history and processing time.
+type QueryHistoryResponse struct {
+	History []QueryHistoryEntry `json:"history"`
+	Took    float64             `json:"took"`
+}
+
 type BlockingStatus struct {
 	Blocking string  `json:"blocking"`
 	Timer    int     `json:"timer"`

--- a/internal/pihole/model.go
+++ b/internal/pihole/model.go
@@ -4,11 +4,11 @@ import "fmt"
 
 // QueryHistoryEntry represents a single entry in the query history.
 type QueryHistoryEntry struct {
-	Timestamp int64 `json:"timestamp"`
-	Total     int   `json:"total"`
-	Cached    int   `json:"cached"`
-	Blocked   int   `json:"blocked"`
-	Forwarded int   `json:"forwarded"`
+	Timestamp int64   `json:"timestamp"`
+	Total     float64 `json:"total"`
+	Cached    float64 `json:"cached"`
+	Blocked   float64 `json:"blocked"`
+	Forwarded float64 `json:"forwarded"`
 }
 
 // QueryHistoryResponse represents the response containing query history and processing time.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,8 @@ func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 	mux.HandleFunc("/metrics", func(writer http.ResponseWriter, request *http.Request) {
 		log.Debugf("request.Header: %+v\n", request.Header)
 
+		// Track start time
+		startTime := time.Now()
 		// Use a WaitGroup to track goroutines
 		var wg sync.WaitGroup
 		// Create a context with timeout for metrics collection
@@ -88,6 +90,10 @@ func NewServer(addr string, port uint16, clients []*pihole.Client) *Server {
 			}
 		}
 
+		// Track end time and print total time taken
+		endTime := time.Now()
+		totalTime := endTime.Sub(startTime)
+		log.Infof("Total time taken for metrics collection: %s", totalTime)
 		promhttp.Handler().ServeHTTP(writer, request)
 	})
 


### PR DESCRIPTION
# Add `pihole_queries_total` counter metric

## Problem

Current metrics (`pihole_dns_queries_today`, `pihole_queries_forwarded`, etc.) are gauges that reset consistently to represent numbers over last 24 hours. They don't work well with Prometheus `rate()` or `increase()` functions, making trend analysis in Grafana unreliable.

May be successor to the metrics removed in #257.

## Solution

New monotonically increasing counter using Pi-hole's `/api/history/database` endpoint:
```promql
pihole_queries_total{hostname="pi.hole", type="blocked"} 12450
pihole_queries_total{hostname="pi.hole", type="cached"} 8932
pihole_queries_total{hostname="pi.hole", type="forwarded"} 15678
```

## How it works

1. **State persistence**: Stores accumulated counts in environment variables (`LAST_QUERY_DATA_<hostname>`)
2. **Incremental queries**: Fetches only new data from Pi-hole since last scrape
3. **Accumulation**: Adds new counts to previous totals (counters never decrease)

**First scrape:**
- Defaults to 120s ago, counters at 0
- Fetches last 120s of history
- Stores accumulated state

**Subsequent scrapes:**
- Reads last timestamp from env var
- Fetches history from last timestamp to `(now - 60s)`
- Adds to previous totals
- Updates stored state

## Usage
```promql
# Query rate over 5 minutes
rate(pihole_queries_total[5m])

# Total queries in last hour by type
sum by (type) (increase(pihole_queries_total[1h]))

# Percentage blocked
rate(pihole_queries_total{type="blocked"}[5m]) / sum(rate(pihole_queries_total[5m])) * 100
```

## Benefits

✅ Prometheus-native counters for accurate `rate()` calculations  
✅ Reliable trend analysis in Grafana  
✅ Efficient - only fetches new data per scrape  
✅ Multi-instance support via per-hostname state  
✅ No external dependencies  

## Configuration

Works out of the box. State persists between scrapes in memory.

**For persistence across container restarts**:
- Not implemented yet.

**For persistence between multiple replicas of exporter**:
- Not implemented yet.

Without persistence, counters reset on restart (Prometheus handles this gracefully).

## Notes

- 60s buffer means most recent data has slight delay
- Tested with 3 Pi-hole instances in Kubernetes

## Breaking Changes

None - purely additive.

## Maintainer Feedback Welcome

First, thank you for building and maintaining this exporter! 🙏

This PR is a **proposal** to address the counter metrics gaps I found. I have this working for me but wanted to get your feedback before investing in a full implementation.

**If this approach looks promising, I'm happy to:**
- Add comprehensive test coverage
- Implement alternative persistence strategies (file-based, optional Redis)
- Convert from Gauge to Counter metric type
- Add configuration options
- Support for high-availability multi-replica deployments
- Update documentation and examples

**Questions for you:**
1. Is this direction aligned with the project's goals?
2. Any concerns about the reliability?
3. Preferences on state storage approach?
4. Should this be opt-in via configuration flag?

I'm committed to maintaining this feature if merged. Looking forward to your thoughts!