### PR TITLE
Suggestion for rootless container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM $IMAGE
 
 LABEL name="pihole-exporter"
 
-WORKDIR /root/
+WORKDIR /app/
 COPY --from=builder /go/src/github.com/eko/pihole-exporter/binary pihole-exporter
 
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ LABEL name="pihole-exporter"
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/eko/pihole-exporter/binary pihole-exporter
 
+USER 65532:65532
+
 CMD ["./pihole-exporter"]


### PR DESCRIPTION
This is a proposal to run the container as a non-root user by default.
The change moves the binary out of /root and sets an unprivileged runtime user, improving container security without affecting functionality. 

I have built and tested the image locally to confirm it runs as expected.