### PR TITLE
changed forward_destinations to short from percent

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1308,7 +1308,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": [
           {


### PR DESCRIPTION
change forward_destinations panel from type "percent" to type "short" as the numbers are absolute values and not percentages.