### PR TITLE
change dns_query_types from percent to short

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1009,7 +1009,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": [
           {


### PR DESCRIPTION
dns_query_types panel uses absolute numbers and not percentages; amended the panel definition to "short" from "percent"